### PR TITLE
Add check for contiguous data in BilinearSampler

### DIFF
--- a/BilinearSamplerBHWD.lua
+++ b/BilinearSamplerBHWD.lua
@@ -27,6 +27,7 @@ function BilinearSamplerBHWD:check(input, gradOutput)
    local inputImages = input[1]
 	local grids = input[2]
 
+   assert(inputImages:isContiguous(), 'Input images have to be contiguous')
    assert(inputImages:nDimension()==4)
    assert(grids:nDimension()==4)
    assert(inputImages:size(1)==grids:size(1)) -- batch


### PR DESCRIPTION
I noticed the output of the BilinearSampler is not consistent across channels (D dimension), when the inputImages are not contiguous. In my case I permuted my input images from BDHW to BHWD, which gave strange issues unless I clone after permuting.

This PR adds a check for contiguity (is that a word?) in the check function.