### PR TITLE
add support for ubuntu 16.04, force inlines

### DIFF
--- a/BilinearSamplerBHWD.lua
+++ b/BilinearSamplerBHWD.lua
@@ -25,7 +25,8 @@ end
 
 function BilinearSamplerBHWD:check(input, gradOutput)
    local inputImages = input[1]
-	local grids = input[2]
+   local grids = input[2]
+      
 
    assert(inputImages:isContiguous(), 'Input images have to be contiguous')
    assert(inputImages:nDimension()==4)
@@ -55,13 +56,11 @@ function BilinearSamplerBHWD:updateOutput(input)
    local _grids = input[2]
 
    local inputImages, grids
-   if _inputImages:nDimension()==3 then
-      inputImages = addOuterDim(_inputImages)
-      grids = addOuterDim(_grids)
-   else
-      inputImages = _inputImages
-      grids = _grids
-   end
+   if _inputImages:nDimension()==3 then inputImages = addOuterDim(_inputImages)   
+   else inputImages = _inputImages end
+   
+   if _grids:nDimension() == 3 then grids = addOuterDim(_grids)
+   else grids = _grids end
 
    local input = {inputImages, grids}
 
@@ -74,30 +73,30 @@ function BilinearSamplerBHWD:updateOutput(input)
    if _inputImages:nDimension()==3 then
       self.output=self.output:select(1,1)
    end
-	
+        
    return self.output
 end
 
 function BilinearSamplerBHWD:updateGradInput(_input, _gradOutput)
-	local _inputImages = _input[1]
-	local _grids = _input[2]
+        local _inputImages = _input[1]
+        local _grids = _input[2]
 
    local inputImages, grids, gradOutput
-   if _inputImages:nDimension()==3 then
-      inputImages = addOuterDim(_inputImages)
-      grids = addOuterDim(_grids)
-      gradOutput = addOuterDim(_gradOutput)
-   else
-      inputImages = _inputImages
-      grids = _grids
-      gradOutput = _gradOutput
-   end
+   --modify the dimension of input
+   if _inputImages:nDimension()==3 then inputImages = addOuterDim(_inputImages)   
+   else inputImages = _inputImages end
+   
+   if _grids:nDimension() == 3 then grids = addOuterDim(_grids)
+   else grids = _grids end
+   
+   if _gradOutput:nDimension() == 3 then gradOutput = addOuterDim(_gradOutput)
+   else gradOutput = _gradOutput end
 
    local input = {inputImages, grids}
 
    self:check(input, gradOutput)
-	for i=1,#input do
-	   self.gradInput[i] = self.gradInput[i] or input[1].new()
+        for i=1,#input do
+           self.gradInput[i] = self.gradInput[i] or input[1].new()
       self.gradInput[i]:resizeAs(input[i]):zero()
    end
 

--- a/stnbhwd-scm-1.rockspec
+++ b/stnbhwd-scm-1.rockspec
@@ -21,7 +21,7 @@ dependencies = {
 build = {
    type = "command",
    build_command = [[
-cmake -E make_directory build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUA_BINDIR)/.." -DCMAKE_INSTALL_PREFIX="$(PREFIX)" && $(MAKE)
+cmake -E make_directory build && cd build && cmake .. -DCMAKE_CXX_FLAGS=-D_FORCE_INLINES -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUA_BINDIR)/.." -DCMAKE_INSTALL_PREFIX="$(PREFIX)" && $(MAKE)
 ]],
    install_command = "cd build && $(MAKE) install"
 }


### PR DESCRIPTION
Fix the bug which will occur on Ubuntu 16.04:
/usr/include/string.h: In function ‘void\* __mempcpy_inline(void_, const void_, size_t)’:
/usr/include/string.h:652:42: error: ‘memcpy’ was not declared in this scope
   return (char *) memcpy (__dest, __src, __n) + __n;
                                          ^
CMake Error at custn_generated_init.cu.o.cmake:266 (message):
  Error generating file
  /tmp/luarocks_stnbhwd-scm-1-9400/stnbhwd/build/CMakeFiles/custn.dir//./custn_generated_init.cu.o
